### PR TITLE
feat: add option to exclude missing query parameters from strict validation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,9 +7,6 @@
     "azureFunctions.projectLanguageModel": 4,
     "azureFunctions.projectSubpath": "packages/ajv-openapi-request-response-validator",
     "azureFunctions.preDeployTask": "npm prune (functions)",
-
-    // Place your settings in this file to overwrite default and user settings.
-{
     "git.ignoreLimitWarning": true,
     "typescript.referencesCodeLens.enabled": true,
     "typescript.preferences.importModuleSpecifier": "relative",
@@ -27,7 +24,11 @@
     "[json]": {
       "editor.formatOnSave": true
     },
-    "eslint.workingDirectories": [{ "mode": "auto" }],
+    "eslint.workingDirectories": [
+      {
+        "pattern": "./packages/*/"
+      }
+    ],
     "eslint.options": {
       "resolvePluginsRelativeTo": "."
     },

--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -17,8 +17,6 @@ module.exports = {
   rules: {
     'unused-imports/no-unused-imports': 'error',
     'require-await': 'error',
-  },
-  settings: {
     '@typescript-eslint/adjacent-overload-signatures': 'error',
     '@typescript-eslint/array-type': ['error'],
     '@typescript-eslint/await-thenable': 'error',

--- a/packages/ajv-openapi-request-response-validator/src/ajv-factory.ts
+++ b/packages/ajv-openapi-request-response-validator/src/ajv-factory.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/naming-convention
 import AjvDraft4 from 'ajv-draft-04'
 import { Options } from 'ajv'
 import addFormats from 'ajv-formats'
@@ -9,7 +10,7 @@ import { AjvExtras, DEFAULT_AJV_EXTRAS, DEFAULT_AJV_SETTINGS } from './ajv-opts'
  * @param validatorOpts - Optional additional validator options
  * @param ajvExtras - Optional additional Ajv features
  */
-export function createAjvInstance(ajvOpts: Options = DEFAULT_AJV_SETTINGS, ajvExtras: AjvExtras = DEFAULT_AJV_EXTRAS) {
+export function createAjvInstance(ajvOpts: Options = DEFAULT_AJV_SETTINGS, ajvExtras: AjvExtras = DEFAULT_AJV_EXTRAS): AjvDraft4 {
   const ajv = new AjvDraft4({ ...DEFAULT_AJV_SETTINGS, ...ajvOpts })
   if (ajvExtras?.addStandardFormats === true) {
     addFormats(ajv)

--- a/packages/ajv-openapi-request-response-validator/src/openapi-validator.ts
+++ b/packages/ajv-openapi-request-response-validator/src/openapi-validator.ts
@@ -122,7 +122,9 @@ export function convertDatesToISOString<T>(data: T): DateToISOString<T> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: any = Array.isArray(data) ? [] : {}
     for (const key in data) {
-      result[key] = convertDatesToISOString(data[key])
+      if (Object.prototype.hasOwnProperty.call(data, key)) {
+        result[key] = convertDatesToISOString(data[key])
+      }
     }
     return result
   }
@@ -134,23 +136,26 @@ export function unserializeParameters(parameters: Record<string, Primitive>): Re
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const result: Record<string, any> = {}
   for (const key in parameters) {
-    const value = parameters[key]
-    let target = result
-    const splitKey = key.split('[')
-    const lastKeyIndex = splitKey.length - 1
+    if (Object.prototype.hasOwnProperty.call(parameters, key)) {
+      const value = parameters[key]
+      let target = result
+      const splitKey = key.split('[')
+      const lastKeyIndex = splitKey.length - 1
 
-    splitKey.forEach((part, index) => {
-      const cleanPart = part.replace(']', '')
+      splitKey.forEach((part, index) => {
+        const cleanPart = part.replace(']', '')
 
-      if (index === lastKeyIndex) {
-        target[cleanPart] = value
-      } else {
-        if (!target[cleanPart]) target[cleanPart] = {}
-        target = target[cleanPart]
-      }
-    })
+        if (index === lastKeyIndex) {
+          target[cleanPart] = value
+        } else {
+          if (!target[cleanPart]) {
+            target[cleanPart] = {}
+          }
+          target = target[cleanPart]
+        }
+      })
+    }
   }
-
   return result
 }
 

--- a/packages/ajv-openapi-request-response-validator/test/.eslintrc.js
+++ b/packages/ajv-openapi-request-response-validator/test/.eslintrc.js
@@ -5,5 +5,9 @@ module.exports = {
       sourceType: 'module',
       tsconfigRootDir: __dirname,
     },
-    extends: ["../.eslintrc.js"]
+    extends: ["../.eslintrc.js"],
+    rules: {
+      "@typescript-eslint/naming-convention": "off",
+      "@typescript-eslint/no-non-null-assertion": "off",
+    }
 }

--- a/packages/ajv-openapi-request-response-validator/test/unit/ajv-validator-api.spec.ts
+++ b/packages/ajv-openapi-request-response-validator/test/unit/ajv-validator-api.spec.ts
@@ -67,6 +67,7 @@ for (const file of files) {
     const testName = path.basename(file, '.js.txt').replace(/-/g, ' ')
     const fixtureContent = fs.readFileSync(path.resolve(fixtureDir, file), { encoding: 'utf-8' })
     try {
+      // eslint-disable-next-line no-eval
       const fixture: TestFixture = eval(fixtureContent)
       if (!onlyInclude || onlyInclude.length === 0 || onlyInclude.find((name) => file.includes(name))) {
         testCases[testName] = fixture
@@ -115,14 +116,14 @@ describe('The api validator', () => {
 
     if (fixture.validateArgs.paths) {
       const params = fixture.request.query ? fixture.request.query : {}
-      for (const [path, method] of Object.entries(fixture.validateArgs.paths)) {
+      for (const [methodPath, method] of Object.entries(fixture.validateArgs.paths)) {
         if (method) {
           for (const [methodName, methodDef] of Object.entries(method)) {
             if (Object.values(OpenAPIV3.HttpMethods).includes(methodName as OpenAPIV3.HttpMethods)) {
               const operation: OpenAPIV3.OperationObject<object> = methodDef
               if (operation.parameters) {
                 const result = validator.validateQueryParams(
-                  path,
+                  methodPath,
                   methodName,
                   params,
                   fixture.requestOpts?.strictQueryParamValidation ?? true
@@ -135,7 +136,7 @@ describe('The api validator', () => {
               }
               if (operation.requestBody && fixture.request.body) {
                 const result = validator.validateRequestBody(
-                  path,
+                  methodPath,
                   methodName,
                   fixture.request.body,
                   fixture.requestOpts?.strictRequestBodyValidation ?? true

--- a/packages/azure-functions-openapi-validator-example/src/functions/test.ts
+++ b/packages/azure-functions-openapi-validator-example/src/functions/test.ts
@@ -29,7 +29,7 @@ app.hook.preInvocation((preContext: PreInvocationContext) => {
   preContext.functionHandler = (origRequest: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> | HttpResponseInit => {
     const result = origHandler(origRequest, context)
     const normalizedQueryParams = preContext.hookData[HOOK_DATA_NORMALIZED_QUERY_PARAMS_KEY]
-    console.log('Normalized query params', JSON.stringify(normalizedQueryParams))
+    context.log('Normalized query params', JSON.stringify(normalizedQueryParams))
     return result
   }
 })
@@ -40,6 +40,7 @@ app.hook.preInvocation((preContext: PreInvocationContext) => {
  */
 app.hook.postInvocation(async () => {
   // Add slight delay to ensure logs show up before the invocation finishes
+  // eslint-disable-next-line @typescript-eslint/no-magic-numbers
   await new Promise((resolve) => setTimeout(resolve, 50))
 })
 

--- a/packages/azure-functions-openapi-validator/README.md
+++ b/packages/azure-functions-openapi-validator/README.md
@@ -27,7 +27,7 @@ const openApiSpec = yaml.load(openApiContent)
 Once you've loaded the specification, use the `setupValidation` function to register the hook.
 
 ```typescript
-import { setupValidation } from '@restfulhead/azure-functions-nodejs-openapi-validator'
+import { setupValidation } from '@restfulhead/azure-functions-openapi-validator'
 
 setupValidation(openApiSpec)
 ```

--- a/packages/azure-functions-openapi-validator/src/app.ts
+++ b/packages/azure-functions-openapi-validator/src/app.ts
@@ -1,11 +1,6 @@
 import { app } from '@azure/functions'
 import { OpenAPIV3 } from 'openapi-types'
-import {
-  DEFAULT_HOOK_OPTIONS,
-  ValidatorHookOptions,
-  configureValidationPostInvocationHandler,
-  configureValidationPreInvocationHandler,
-} from './validation-hook-setup'
+// eslint-disable-next-line @typescript-eslint/naming-convention
 import Ajv, { Options } from 'ajv'
 import {
   AjvOpenApiValidator,
@@ -14,6 +9,12 @@ import {
   ValidatorOpts,
   createAjvInstance,
 } from '@restfulhead/ajv-openapi-request-response-validator'
+import {
+  DEFAULT_HOOK_OPTIONS,
+  ValidatorHookOptions,
+  configureValidationPostInvocationHandler,
+  configureValidationPreInvocationHandler,
+} from './validation-hook-setup'
 
 function isAjvInstance(ajv: undefined | Options | Ajv): ajv is Ajv {
   return ajv !== undefined && (ajv as Ajv).addSchema !== undefined
@@ -24,7 +25,7 @@ export function setupValidation(
   optsHook: ValidatorHookOptions = DEFAULT_HOOK_OPTIONS,
   optsValidator: ValidatorOpts = DEFAULT_VALIDATOR_OPTS,
   optsAjc: Options | Ajv = DEFAULT_AJV_SETTINGS
-) {
+): void {
   const ajv = isAjvInstance(optsAjc) ? optsAjc : createAjvInstance(optsAjc as Options | undefined)
   const validator = new AjvOpenApiValidator(spec, ajv, optsValidator)
 

--- a/packages/azure-functions-openapi-validator/src/helper.ts
+++ b/packages/azure-functions-openapi-validator/src/helper.ts
@@ -1,7 +1,11 @@
 import { HttpResponseInit, InvocationContext } from '@azure/functions'
 import { HeadersInit } from 'undici'
 
-export const createJsonResponse = (body: unknown, status: number = 200, headers?: HeadersInit): HttpResponseInit => {
+export const STATUS_CODE_OK = 200
+export const STATUS_CODE_BAD_REQUEST = 400
+export const STATUS_CODE_INTERNAL_SERVER_ERROR = 500
+
+export const createJsonResponse = (body: unknown, status = STATUS_CODE_OK, headers?: HeadersInit): HttpResponseInit => {
   const finalHeaders: HeadersInit = headers ?? {}
   if (!(finalHeaders as Record<string, string>)['Content-Type']) {
     ;(finalHeaders as Record<string, string>)['Content-Type'] = 'application/json'
@@ -16,7 +20,7 @@ export const createJsonResponse = (body: unknown, status: number = 200, headers?
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'off'
 
-export const logMessage = (msg: string, logLevel: LogLevel, context: InvocationContext) => {
+export const logMessage = (msg: string, logLevel: LogLevel, context: InvocationContext): void => {
   switch (logLevel) {
     case 'debug':
       context.debug(msg)

--- a/packages/azure-functions-openapi-validator/test/.eslintrc.js
+++ b/packages/azure-functions-openapi-validator/test/.eslintrc.js
@@ -5,5 +5,9 @@ module.exports = {
       sourceType: 'module',
       tsconfigRootDir: __dirname,
     },
-    extends: ["../.eslintrc.js"]
+    extends: ["../.eslintrc.js"],
+    rules: {
+      "@typescript-eslint/no-magic-numbers": "off",
+      "no-console": "off"
+    }
 }


### PR DESCRIPTION
By default, we now ignore if a query parameter `code` is supplied but not specified even in strict mode. The Azure portal seems to pass in the function key via query param instead of header value. So to make the portal work without having to specify the `code` query parameter in our API, we have to ignore this.

This PR also contains a lot of lint/code quality fixes which were missed before due to an invalid eslint configuration.